### PR TITLE
Drop DualNumbers, use ForwardDiff for tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.1'
+          - '1.6'
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterPenalty"
 uuid = "464fa2a9-b19c-5c59-8698-f58c971f971e"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 CachedInterpolations = "b9709bfb-d23d-5560-8276-8c35c4b76823"
@@ -23,12 +23,11 @@ RegisterCore = "0.2.1"
 RegisterDeformation = "0.3"
 RegisterUtilities = "0.1"
 StaticArrays = "0.10, 0.11, 0.12"
-julia = "1.1"
+julia = "1.6"
 
 [extras]
-DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DualNumbers", "ForwardDiff", "Test"]
+test = ["ForwardDiff", "Test"]


### PR DESCRIPTION
DualNumbers was the old way before the arrival of ForwardDiff,
but the tests in this package never fully updated to ForwardDiff.

This also bumps the Julia [compat] to 1.6 so as to take advantage
of `reinterpret(reshape, ...)`.