### PR TITLE
Fix temporal penalty test: use zeros instead of similar

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,7 +218,7 @@ end
 
     cnvt = x->RegisterPenalty.vec2ϕs(x, gsize, n, nodes)
     ϕs = cnvt(x)
-    g = similar(x)
+    g = zeros(size(x))
     val = RegisterPenalty.penalty!(g, 1.0, ϕs)
     gfx = ForwardDiff.gradient(x->RegisterPenalty.penalty(1.0, cnvt(x)), x)
     @test vec(g) ≈ gfx


### PR DESCRIPTION
## Summary
- `penalty!(g, λt, ϕs)` accumulates into `g` via `+=`/`-=`, so callers must zero-initialize it
- The test was using `similar(x)` (uninitialized memory), causing NaN values in the last timepoint's gradient entries
- Fixed by changing `similar(x)` to `zeros(size(x))`

## Test plan
- [x] `Pkg.test()` passes (all 4 testsets green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)