### PR TITLE
Apply runic formatting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterPenalty"
 uuid = "464fa2a9-b19c-5c59-8698-f58c971f971e"
-authors = ["Tim Holy <tim.holy@gmail.com>"]
 version = "0.3.3"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
 
 [deps]
 CachedInterpolations = "b9709bfb-d23d-5560-8276-8c35c4b76823"

--- a/src/RegisterPenalty.jl
+++ b/src/RegisterPenalty.jl
@@ -27,12 +27,12 @@ The main exported types/functions are:
 RegisterPenalty
 
 
-abstract type DeformationPenalty{T,N} end
-Base.eltype(::Type{DeformationPenalty{T,N}}) where {T,N} = T
-Base.eltype(::Type{DP}) where {DP<:DeformationPenalty} = eltype(supertype(DP))
+abstract type DeformationPenalty{T, N} end
+Base.eltype(::Type{DeformationPenalty{T, N}}) where {T, N} = T
+Base.eltype(::Type{DP}) where {DP <: DeformationPenalty} = eltype(supertype(DP))
 Base.eltype(dp::DeformationPenalty) = eltype(typeof(dp))
-Base.ndims(::Type{DeformationPenalty{T,N}}) where {T,N} = N
-Base.ndims(::Type{DP}) where {DP<:DeformationPenalty} = ndims(supertype(DP))
+Base.ndims(::Type{DeformationPenalty{T, N}}) where {T, N} = N
+Base.ndims(::Type{DP}) where {DP <: DeformationPenalty} = ndims(supertype(DP))
 Base.ndims(dp::DeformationPenalty) = ndims(typeof(dp))
 
 """
@@ -88,13 +88,13 @@ function penalty!(g, ϕ, ϕ_old, dp::DeformationPenalty, mmis::AbstractArray, ke
     end
     # Data penalty
     val += penalty!(g, ϕ, mmis, keep)
-    convert(T, val)
+    return convert(T, val)
 end
 
 # Allow it to be called without StaticArrays
-function penalty!(g::Array{T}, ϕ, ϕ_old, dp::DeformationPenalty, mmis::AbstractArray, keep = trues(size(mmis))) where T<:Number
+function penalty!(g::Array{T}, ϕ, ϕ_old, dp::DeformationPenalty, mmis::AbstractArray, keep = trues(size(mmis))) where {T <: Number}
     gf = RegisterDeformation.convert_to_fixed(g, (ndims(dp), size(ϕ.u)...))
-    penalty!(gf, ϕ, ϕ_old, dp, mmis, keep)
+    return penalty!(gf, ϕ, ϕ_old, dp, mmis, keep)
 end
 
 
@@ -104,24 +104,24 @@ evaluates the total penalty for temporal sequence of deformations
 `ϕs`, using the temporal sequence of mismatch data `mmis`.  `λt` is
 the temporal roughness penalty coefficient.
 """
-function penalty!(gs, ϕs::AbstractVector{D}, ϕs_old, dp::DeformationPenalty, λt::Number, mmis::AbstractArray, keep = trues(size(mmis))) where D<:AbstractDeformation
+function penalty!(gs, ϕs::AbstractVector{D}, ϕs_old, dp::DeformationPenalty, λt::Number, mmis::AbstractArray, keep = trues(size(mmis))) where {D <: AbstractDeformation}
     ntimes = length(ϕs)
     size(mmis)[end] == ntimes || throw(DimensionMismatch("Number of deformations $ntimes does not agree with mismatch data of size $(size(mmis))"))
     s = _penalty!(gs, ϕs, ϕs_old, dp, mmis, keep, 1)
-    for i = 2:ntimes
+    for i in 2:ntimes
         isfinite(s) || break
         s += _penalty!(gs, ϕs, ϕs_old, dp, mmis, keep, i)
     end
-    s + penalty!(gs, λt, ϕs)
+    return s + penalty!(gs, λt, ϕs)
 end
 
 
-function penalty!(gs::Array{T}, ϕs::AbstractVector{D}, ϕs_old, dp::DeformationPenalty, λt::Number, mmis::AbstractArray, keep = trues(size(mmis))) where {T<:Number,D<:AbstractDeformation}
+function penalty!(gs::Array{T}, ϕs::AbstractVector{D}, ϕs_old, dp::DeformationPenalty, λt::Number, mmis::AbstractArray, keep = trues(size(mmis))) where {T <: Number, D <: AbstractDeformation}
     gf = RegisterDeformation.convert_to_fixed(gs, (ndims(dp), size(first(ϕs).u)..., length(ϕs)))
-    penalty!(gf, ϕs, ϕs_old, dp, λt, mmis, keep)
+    return penalty!(gf, ϕs, ϕs_old, dp, λt, mmis, keep)
 end
 
-function _penalty!(gs, ϕs, ϕs_old, dp::DeformationPenalty{T,N}, mmis, keeps, i) where {T,N}
+function _penalty!(gs, ϕs, ϕs_old, dp::DeformationPenalty{T, N}, mmis, keeps, i) where {T, N}
     colons = ntuple(ColonFun, Val(N))
     indexes = (colons..., i)
     #mmi = view(mmis, indexes...)  # making these views runs afoul of inference limits
@@ -130,7 +130,7 @@ function _penalty!(gs, ϕs, ϕs_old, dp::DeformationPenalty{T,N}, mmis, keeps, i
     keep = keeps[indexes...]
     calc_gradient = gs != nothing && !isempty(gs)
     g = calc_gradient ? view(gs, indexes...) : nothing
-    if isa(ϕs_old, AbstractVector)
+    return if isa(ϕs_old, AbstractVector)
         penalty!(g, ϕs[i], ϕs_old[i], dp, mmi, keep)
     else
         penalty!(g, ϕs[i], ϕs_old, dp, mmi, keep)
@@ -142,7 +142,7 @@ end
 # Data penalty #
 ################
 
-const CenteredInterpolant{T,N,A<:AbstractInterpolation} = Union{MismatchArray{T,N,A}, CachedInterpolation{T,N}}
+const CenteredInterpolant{T, N, A <: AbstractInterpolation} = Union{MismatchArray{T, N, A}, CachedInterpolation{T, N}}
 
 """
 `p = penalty!(g, ϕ, mmis, [keep=trues(size(mmis))])` computes the
@@ -168,16 +168,16 @@ where each index `_i` refers to a single aperture, and each `p_i`
 involves just `mmis[i]` and `ϕ.u[:,i]`.  `mmis[i]` must be
 interpolating, so that it can be evaluated for fractional shifts.
 """
-function penalty!(g, ϕ::AbstractDeformation, mmis::AbstractArray{M}, keep=trues(size(mmis))) where M<:CenteredInterpolant
-    penalty!(g, ϕ.u, mmis, keep)
+function penalty!(g, ϕ::AbstractDeformation, mmis::AbstractArray{M}, keep = trues(size(mmis))) where {M <: CenteredInterpolant}
+    return penalty!(g, ϕ.u, mmis, keep)
 end
 
-function penalty!(g::Array{Tg}, ϕ::AbstractDeformation, mmis::AbstractArray{M}, keep=trues(size(mmis))) where {Tg<:Number,M<:CenteredInterpolant}
+function penalty!(g::Array{Tg}, ϕ::AbstractDeformation, mmis::AbstractArray{M}, keep = trues(size(mmis))) where {Tg <: Number, M <: CenteredInterpolant}
     gf = RegisterDeformation.convert_to_fixed(g, (ndims(ϕ), size(ϕ.u)...))
-    penalty!(gf, ϕ, mmis, keep)
+    return penalty!(gf, ϕ, mmis, keep)
 end
 
-function penalty!(g, u::AbstractArray{SVector{Dim,Tu}}, mmis::AbstractArray{M}, keep=trues(size(mmis))) where {Tu,Dim,M<:CenteredInterpolant}
+function penalty!(g, u::AbstractArray{SVector{Dim, Tu}}, mmis::AbstractArray{M}, keep = trues(size(mmis))) where {Tu, Dim, M <: CenteredInterpolant}
     # This "outer" function just handles the chain rule for computing the
     # total penalty and gradient. The "real" work is done by penalty_nd!.
     nblocks = length(mmis)
@@ -189,19 +189,19 @@ function penalty!(g, u::AbstractArray{SVector{Dim,Tu}}, mmis::AbstractArray{M}, 
         end
     end
     if calc_gradient
-        gnd = similar(u, SVector{Dim,NumDenom{Tu}})
+        gnd = similar(u, SVector{Dim, NumDenom{Tu}})
         nd = penalty_nd!(gnd, u, mmis, keep)
         N, D = nd.num, nd.denom
-        invD = 1/D
-        NinvD2 = N*invD*invD
-        for i = 1:length(g)
+        invD = 1 / D
+        NinvD2 = N * invD * invD
+        for i in 1:length(g)
             g[i] += _wsum(gnd[i], invD, -NinvD2)
         end
-        return N*invD
+        return N * invD
     else
         nd = penalty_nd!(g, u, mmis, keep)
         N, D = nd.num, nd.denom
-        return N/D
+        return N / D
     end
 end
 
@@ -211,24 +211,24 @@ function penalty_nd!(gnd, u::AbstractArray, mmis, keep)
     T = eltype(eltype(u))
     calc_grad = gnd != nothing && !isempty(gnd)
     mxs = maxshift(first(mmis))
-    nd = NumDenom{T}(0,0)
+    nd = NumDenom{T}(0, 0)
     nanT = convert(T, NaN)
     local gtmp
     if calc_grad
         gtmp = Vector{NumDenom{T}}(undef, N)
     end
-    for iblock = 1:length(mmis)
+    for iblock in 1:length(mmis)
         mmi = mmis[iblock]
         if !keep[iblock]
             if calc_grad
-                gnd[iblock] = NumDenom{T}(0,0)
+                gnd[iblock] = NumDenom{T}(0, 0)
             end
             continue
         end
         # Check bounds
         dx = u[iblock]
         if !checkbounds_shift(dx, mxs)
-            return NumDenom{T}(nanT,nanT)
+            return NumDenom{T}(nanT, nanT)
         end
         # Evaluate the value
         nd += vecindex(mmi, dx)
@@ -238,21 +238,25 @@ function penalty_nd!(gnd, u::AbstractArray, mmis, keep)
             gnd[iblock] = gtmp
         end
     end
-    nd
+    return nd
 end
 
 penalty_nd!(gnd, u::AbstractInterpolation, mmis, keep) = error("ϕ must not be interpolating")
 
-@generated function checkbounds_shift(dx::SVector{N}, mxs) where N
-    quote
-        @nexprs $N d->(if abs(dx[d]) >= mxs[d]-0.5 return false end)
+@generated function checkbounds_shift(dx::SVector{N}, mxs) where {N}
+    return quote
+        @nexprs $N d -> (
+            if abs(dx[d]) >= mxs[d] - 0.5
+                return false
+            end
+        )
         true
     end
 end
 
-@generated function _wsum(x::SVector{N}, cnum, cdenom) where N
-    args = [:(cnum*x[$d].num + cdenom*x[$d].denom) for d = 1:N]
-    quote
+@generated function _wsum(x::SVector{N}, cnum, cdenom) where {N}
+    args = [:(cnum * x[$d].num + cdenom * x[$d].denom) for d in 1:N]
+    return quote
         SVector($(args...))
     end
 end
@@ -276,38 +280,38 @@ When the deformation is defined on a regular grid, `nodes` can be an
 NTuple of node-vectors; otherwise, it should be an
 `ndims`-by-`npoints` matrix that stores the node locations in columns.
 """
-mutable struct AffinePenalty{T,N} <: DeformationPenalty{T,N}
+mutable struct AffinePenalty{T, N} <: DeformationPenalty{T, N}
     F::Matrix{T}   # geometry data for the affine-residual penalty
     λ::T           # regularization coefficient
 
-    AffinePenalty{T,N}(F::Matrix{T}, λ::T, _) where {T,N} = new{T,N}(F, λ)
+    AffinePenalty{T, N}(F::Matrix{T}, λ::T, _) where {T, N} = new{T, N}(F, λ)
 
-    function AffinePenalty{T,N}(nodes::NTuple{N}, λ) where {T,N}
+    function AffinePenalty{T, N}(nodes::NTuple{N}, λ) where {T, N}
         gridsize = map(length, nodes)
-        C = Matrix{Float64}(undef, prod(gridsize), N+1)
+        C = Matrix{Float64}(undef, prod(gridsize), N + 1)
         i = 0
         for I in CartesianIndices(gridsize)
-            C[i+=1, N+1] = 1
-            for j = 1:N
+            C[i += 1, N + 1] = 1
+            for j in 1:N
                 C[i, j] = nodes[j][I[j]]  # I[j]
             end
         end
         F, _ = qr(C)
-        new{T,N}(Array(F), λ)
+        return new{T, N}(Array(F), λ)
     end
 
-    function AffinePenalty{T,N}(nodes::AbstractMatrix, λ) where {T,N}
+    function AffinePenalty{T, N}(nodes::AbstractMatrix, λ) where {T, N}
         C = hcat(nodes', ones(eltype(nodes), size(nodes, 2)))
         F, _ = qr(C)
-        new{T,N}(F, λ)
+        return new{T, N}(F, λ)
     end
 end
 
-AffinePenalty(nodes::NTuple{N,V}, λ) where {V<:AbstractVector,N} = AffinePenalty{eltype(V),N}(nodes, λ)
-AffinePenalty(nodes::AbstractVector{V}, λ) where {V<:AbstractVector} = AffinePenalty{eltype(V),length(nodes)}((nodes...,), λ)
-AffinePenalty(nodes::AbstractMatrix{T}, λ) where {T} = AffinePenalty{T,size(nodes,1)}(nodes, λ)
+AffinePenalty(nodes::NTuple{N, V}, λ) where {V <: AbstractVector, N} = AffinePenalty{eltype(V), N}(nodes, λ)
+AffinePenalty(nodes::AbstractVector{V}, λ) where {V <: AbstractVector} = AffinePenalty{eltype(V), length(nodes)}((nodes...,), λ)
+AffinePenalty(nodes::AbstractMatrix{T}, λ) where {T} = AffinePenalty{T, size(nodes, 1)}(nodes, λ)
 
-Base.convert(::Type{AffinePenalty{T,N}}, ap::AffinePenalty) where {T,N} = AffinePenalty{T,N}(convert(Matrix{T}, ap.F), convert(T, ap.λ), 0)
+Base.convert(::Type{AffinePenalty{T, N}}, ap::AffinePenalty) where {T, N} = AffinePenalty{T, N}(convert(Matrix{T}, ap.F), convert(T, ap.λ), 0)
 
 """
 `p = penalty!(g, dp::DeformationPenalty, ϕ_c, [g_c])` computes the
@@ -324,11 +328,11 @@ If `g` is non-empty, the gradient of the penalty with respect to `u`
 will be computed.  If you write a custom `penalty!` function for a new
 `DeformationPenalty`, it is your responsibility to set `g` in-place.
 """
-function penalty!(g, dp::AffinePenalty, ϕ_c::AbstractDeformation{T,N}) where {T,N}
-    penalty!(g, dp, ϕ_c.u)
+function penalty!(g, dp::AffinePenalty, ϕ_c::AbstractDeformation{T, N}) where {T, N}
+    return penalty!(g, dp, ϕ_c.u)
 end
 
-function penalty!(g, dp::AffinePenalty, u::AbstractArray{SVector{N,T},N}) where {T,N}
+function penalty!(g, dp::AffinePenalty, u::AbstractArray{SVector{N, T}, N}) where {T, N}
     F, λ = dp.F, dp.λ
     if λ == 0
         if g != nothing && !isempty(g)
@@ -338,27 +342,27 @@ function penalty!(g, dp::AffinePenalty, u::AbstractArray{SVector{N,T},N}) where 
     end
     n = length(u)
     U = convert_from_fixed(u, (n,))
-    A = (U*F)*F'   # projection onto an affine transformation
-    dU = U-A
+    A = (U * F) * F'   # projection onto an affine transformation
+    dU = U - A
     λ /= n
     if g != nothing && !isempty(g)
         λ2 = 2λ
-        du = convert_to_fixed(SVector{N,T}, dU, (n,))
-        for j=1:n
-            g[j] = λ2*du[j]
+        du = convert_to_fixed(SVector{N, T}, dU, (n,))
+        for j in 1:n
+            g[j] = λ2 * du[j]
         end
     end
-    λ * sum(abs2, dU)
+    return λ * sum(abs2, dU)
 end
 
 function penalty!(g, dp::AffinePenalty, ϕ_c, g_c)
     ret = penalty!(g, dp, ϕ_c)
     if g != nothing
-        for i = 1:length(g)
-            g[i] = g_c[i]'*g[i]
+        for i in 1:length(g)
+            g[i] = g_c[i]' * g[i]
         end
     end
-    ret
+    return ret
 end
 
 ###
@@ -373,62 +377,62 @@ for a vector `ϕ` of deformations. `g`, if not `nothing`, should be a
 single real-valued vector with number of entries corresponding to all
 of the `u` arrays in all of `ϕs`.
 """
-function penalty!(g, λt::Real, ϕs::Vector{D}) where D<:GridDeformation
+function penalty!(g, λt::Real, ϕs::Vector{D}) where {D <: GridDeformation}
     if g == nothing || isempty(g)
         return penalty(λt, ϕs)
     end
     ngrid = length(first(ϕs).u)
-    if length(g) != length(ϕs)*ngrid
+    if length(g) != length(ϕs) * ngrid
         gsize = (size(first(ϕs).u)..., length(ϕs))
         throw(DimensionMismatch("g's length $(length(g)) inconsistent with $gsize"))
     end
     local s = zero(eltype(D))
-    λt2 = λt/2
-    for i = 1:length(ϕs)-1
-        ϕ  = ϕs[i]
-        ϕp = ϕs[i+1]
-        goffset = ngrid*(i-1)
-        for k = 1:ngrid
+    λt2 = λt / 2
+    for i in 1:(length(ϕs) - 1)
+        ϕ = ϕs[i]
+        ϕp = ϕs[i + 1]
+        goffset = ngrid * (i - 1)
+        for k in 1:ngrid
             du = ϕp.u[k] - ϕ.u[k]
-            dv = λt*du
-            g[goffset+k] -= dv
-            g[goffset+ngrid+k] += dv
-            s += λt2*sum(abs2, du)
+            dv = λt * du
+            g[goffset + k] -= dv
+            g[goffset + ngrid + k] += dv
+            s += λt2 * sum(abs2, du)
         end
     end
-    s
+    return s
 end
 
-function penalty!(g::Array{T}, λt::Real, ϕs::Vector{D}) where {T<:Number, D<:GridDeformation}
+function penalty!(g::Array{T}, λt::Real, ϕs::Vector{D}) where {T <: Number, D <: GridDeformation}
     N = ndims(first(ϕs))
     sz = size(first(ϕs).u)
     gf = RegisterDeformation.convert_to_fixed(g, (N, sz..., length(ϕs)))
-    penalty!(gf, λt, ϕs)
+    return penalty!(gf, λt, ϕs)
 end
 
-function penalty(λt::Real, ϕs::Vector{D}) where D<:GridDeformation
+function penalty(λt::Real, ϕs::Vector{D}) where {D <: GridDeformation}
     s = zero(eltype(D))
     ngrid = length(first(ϕs).u)
-    λt2 = λt/2
-    for i = 1:length(ϕs)-1
-        ϕ  = ϕs[i]
-        ϕp = ϕs[i+1]
-        for k = 1:ngrid
+    λt2 = λt / 2
+    for i in 1:(length(ϕs) - 1)
+        ϕ = ϕs[i]
+        ϕp = ϕs[i + 1]
+        for k in 1:ngrid
             du = ϕp.u[k] - ϕ.u[k]
-            s += λt2*sum(abs2, du)
+            s += λt2 * sum(abs2, du)
         end
     end
-    s
+    return s
 end
 
-function RegisterDeformation.convert_to_fixed(::Type{GridDeformation{T,N,A,L}}, g::Array{T}) where {T,N,A,L}
-    reshape(reinterpret(SVector{N,T}, g), (div(length(g), N),))
+function RegisterDeformation.convert_to_fixed(::Type{GridDeformation{T, N, A, L}}, g::Array{T}) where {T, N, A, L}
+    return reshape(reinterpret(SVector{N, T}, g), (div(length(g), N),))
 end
 
-function vec2ϕs(x::Array{T}, gridsize::NTuple{N,Int}, n, nodes) where {T,N}
-    xr = RegisterDeformation.convert_to_fixed(SVector{N,T}, x, (gridsize..., n))
-    colons = ntuple(d->Colon(), N)::NTuple{N,Colon}
-    [GridDeformation(view(xr, colons..., i), nodes) for i = 1:n]
+function vec2ϕs(x::Array{T}, gridsize::NTuple{N, Int}, n, nodes) where {T, N}
+    xr = RegisterDeformation.convert_to_fixed(SVector{N, T}, x, (gridsize..., n))
+    colons = ntuple(d -> Colon(), N)::NTuple{N, Colon}
+    return [GridDeformation(view(xr, colons..., i), nodes) for i in 1:n]
 end
 
 """
@@ -444,16 +448,16 @@ you want to specify the boundary condition (default is `InPlace()`).
 `mmis = interpolate_mm!(mms, order)` prepares the array-of-MismatchArrays
 `mms` for interpolation.
 """
-function interpolate_mm!(mms::AbstractArray{T}, itype::Interpolations.InterpolationType) where T<:MismatchArray
-    f = x->CenterIndexedArray(interpolate!(x.data, itype))
-    map(f, mms)
+function interpolate_mm!(mms::AbstractArray{T}, itype::Interpolations.InterpolationType) where {T <: MismatchArray}
+    f = x -> CenterIndexedArray(interpolate!(x.data, itype))
+    return map(f, mms)
 end
 
 function interpolate_mm!(mm::MismatchArray, itype::Interpolations.InterpolationType)
-    CenterIndexedArray(interpolate!(mm.data, itype))
+    return CenterIndexedArray(interpolate!(mm.data, itype))
 end
 
-interpolate_mm!(arg, ::Type{order}) where {order<:Interpolations.Degree} =
+interpolate_mm!(arg, ::Type{order}) where {order <: Interpolations.Degree} =
     interpolate_mm!(arg, itptype(order))
 
 interpolate_mm!(arg) = interpolate_mm!(arg, Quadratic)
@@ -461,11 +465,11 @@ interpolate_mm!(arg) = interpolate_mm!(arg, Quadratic)
 itptype(::Type{Quadratic}) = BSpline(Quadratic(InPlace(OnCell())))
 itptype(::Type{Linear}) = Gridded(Linear())
 
-@generated function Interpolations.gradient!(g::AbstractVector, A::CenterIndexedArray{T,N}, i::Number...) where {T,N}
+@generated function Interpolations.gradient!(g::AbstractVector, A::CenterIndexedArray{T, N}, i::Number...) where {T, N}
     length(i) == N || error("Must use $N indexes")
-    args = [:(i[$d]+A.halfsize[$d]+1) for  d = 1:N]
+    args = [:(i[$d] + A.halfsize[$d] + 1) for  d in 1:N]
     meta = Expr(:meta, :inline)
-    :($meta; Interpolations.gradient!(g, A.data, $(args...)))
+    return :($meta; Interpolations.gradient!(g, A.data, $(args...)))
 end
 
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,44 +10,44 @@ using RegisterUtilities
 accuracy = 10 # for new isapprox method
 
 @testset "Affine penalty" begin
-    gridsize = (9,7)
-    maxshift = (3,3)
-    imgaxs = map(Base.OneTo, (1000,1002))
+    gridsize = (9, 7)
+    maxshift = (3, 3)
+    imgaxs = map(Base.OneTo, (1000, 1002))
     nodes = map(imgaxs, gridsize) do ax, g
-        range(first(ax), stop=last(ax), length=g)
+        range(first(ax), stop = last(ax), length = g)
     end
     dp = RegisterPenalty.AffinePenalty(nodes, 1.0)
     @test typeof(dp) == RegisterPenalty.AffinePenalty{Float64, 2}
     # Since the constructor performs matrix algebra on an array input,
     # test that `convert` doesn't mangle F.
-    @test ≈(convert(RegisterPenalty.AffinePenalty{Float32,2}, dp).F, dp.F, atol=1e-7*accuracy)
+    @test ≈(convert(RegisterPenalty.AffinePenalty{Float32, 2}, dp).F, dp.F, atol = 1.0e-7 * accuracy)
 
     # Zero penalty for translations
-    ϕ_new = tform2deformation(tformtranslate([0.3,0.05]), imgaxs, gridsize)
-    ϕ_old = interpolate(tform2deformation(tformtranslate([0.1,0.2]),  imgaxs, gridsize))
+    ϕ_new = tform2deformation(tformtranslate([0.3, 0.05]), imgaxs, gridsize)
+    ϕ_old = interpolate(tform2deformation(tformtranslate([0.1, 0.2]), imgaxs, gridsize))
     g = similar(ϕ_new.u)
-    @test @inferred(abs(RP.penalty!(g, dp, ϕ_new))) < 1e-12
-    @test all(x->sum(abs, x) < 1e-12, g)
+    @test @inferred(abs(RP.penalty!(g, dp, ϕ_new))) < 1.0e-12
+    @test all(x -> sum(abs, x) < 1.0e-12, g)
     ϕ_c, g_c = compose(ϕ_old, ϕ_new)
-    @test @inferred(abs(RP.penalty!(g, dp, ϕ_c, g_c))) < 1e-12
-    @test all(x->sum(abs, x) < 1e-12, g)
+    @test @inferred(abs(RP.penalty!(g, dp, ϕ_c, g_c))) < 1.0e-12
+    @test all(x -> sum(abs, x) < 1.0e-12, g)
 
     # Zero penalty for rotations
-    ϕ = tform2deformation(tformrotate(10pi/180), imgaxs, gridsize)
-    @test abs(RP.penalty!(g, dp, ϕ)) < 1e-12
-    @test all(x->sum(abs, x) < 1e-12, g)
+    ϕ = tform2deformation(tformrotate(10pi / 180), imgaxs, gridsize)
+    @test abs(RP.penalty!(g, dp, ϕ)) < 1.0e-12
+    @test all(x -> sum(abs, x) < 1.0e-12, g)
 
     # Zero penalty for stretch and skew
-    A = 0.2*rand(2,2) + Matrix{Float64}(I,2,2)
-    tform = AffineMap(A, Int[g>>1 for g in gridsize])
+    A = 0.2 * rand(2, 2) + Matrix{Float64}(I, 2, 2)
+    tform = AffineMap(A, Int[g >> 1 for g in gridsize])
     ϕ = tform2deformation(tform, imgaxs, gridsize)
-    @test abs(RP.penalty!(g, dp, ϕ)) < 1e-12
-    @test all(x->sum(abs, x) < 1e-12, g)
+    @test abs(RP.penalty!(g, dp, ϕ)) < 1.0e-12
+    @test all(x -> sum(abs, x) < 1.0e-12, g)
 
     # Random deformations & affine-residual penalty
-    gridsize = (3,3)
+    gridsize = (3, 3)
     nodes = map(imgaxs, gridsize) do ax, g
-        range(first(ax), stop=last(ax), length=g)
+        range(first(ax), stop = last(ax), length = g)
     end
     dp = RegisterPenalty.AffinePenalty(nodes, 1.0)
     u = randn(2, gridsize...)
@@ -68,12 +68,12 @@ end
 # Data penalty #
 ################
 @testset "Data penalty" begin
-    gridsize = (1,1)
-    maxshift = (3,3)
-    imgaxs = map(Base.OneTo, (1,1))
+    gridsize = (1, 1)
+    maxshift = (3, 3)
+    imgaxs = map(Base.OneTo, (1, 1))
 
-    p = [(x-1.75)^2 for x = 1:7]
-    nums = reshape(p*p', length(p), length(p))
+    p = [(x - 1.75)^2 for x in 1:7]
+    nums = reshape(p * p', length(p), length(p))
     denoms = similar(nums); fill!(denoms, 1)
     mm = MismatchArray(nums, denoms)
     mmi = RP.interpolate_mm!(mm, BSpline(Quadratic(InPlaceQ(OnCell()))))
@@ -82,45 +82,45 @@ end
     g = similar(ϕ.u)
     fill!(g, zero(eltype(g)))
     val = @inferred(RP.penalty!(g, ϕ, mmi_array))
-    @test val ≈ (4-1.75)^4
-    @test g[1][1] ≈ 2*(4-1.75)^3
+    @test val ≈ (4 - 1.75)^4
+    @test g[1][1] ≈ 2 * (4 - 1.75)^3
     # Test at the minimum
     fill!(g, zero(eltype(g)))
-    ϕ = GridDeformation(reshape([-2.25,-2.25], (2,1,1)), imgaxs)
+    ϕ = GridDeformation(reshape([-2.25, -2.25], (2, 1, 1)), imgaxs)
     @test RP.penalty!(g, ϕ, mmi_array) < eps()
     @test abs(g[1][1]) < eps()
 
 
     # A biquadratic penalty---make sure we calculate the exact values
-    gridsize = (2,2)
-    maxshift = [3,4]
-    imgaxs = map(Base.OneTo, (101,100))
+    gridsize = (2, 2)
+    maxshift = [3, 4]
+    imgaxs = map(Base.OneTo, (101, 100))
 
     minrange = 1.6
-    maxrange = Float64[2*m+1-0.6 for m in maxshift]
-    dr = maxrange.-minrange
-    c = dr.*rand(2, gridsize...).+minrange
+    maxrange = Float64[2 * m + 1 - 0.6 for m in maxshift]
+    dr = maxrange .- minrange
+    c = dr .* rand(2, gridsize...) .+ minrange
     nums = Matrix{Matrix{Float64}}(undef, 2, 2)
-    shiftsize = 2maxshift.+1
-    for j = 1:gridsize[2], i = 1:gridsize[1]
-        p = [(x-c[1,i,j])^2 for x in 1:shiftsize[1]]
-        q = [(x-c[2,i,j])^2 for x in 1:shiftsize[2]]
-        nums[i,j] = p*q'
+    shiftsize = 2maxshift .+ 1
+    for j in 1:gridsize[2], i in 1:gridsize[1]
+        p = [(x - c[1, i, j])^2 for x in 1:shiftsize[1]]
+        q = [(x - c[2, i, j])^2 for x in 1:shiftsize[2]]
+        nums[i, j] = p * q'
     end
-    denom = fill!(similar(nums[1,1]),1)
+    denom = fill!(similar(nums[1, 1]), 1)
     mms = mismatcharrays(nums, denom)
     mmis = RP.interpolate_mm!(mms, BSpline(Quadratic(InPlaceQ(OnCell()))))
-    u_real = (dr.*rand(2, gridsize...).+minrange) .- Float64[m+1 for m in maxshift]  #zeros(size(c)...)
+    u_real = (dr .* rand(2, gridsize...) .+ minrange) .- Float64[m + 1 for m in maxshift]  #zeros(size(c)...)
     ϕ = GridDeformation(u_real, imgaxs)
     g = similar(ϕ.u)
     fill!(g, zero(eltype(g)))
     val = @inferred(RP.penalty!(g, ϕ, mmis))
     nblocks = prod(gridsize)
-    valpred = sum([prod([(maxshift[k]+1+u_real[k,i,j]-c[k,i,j])^2 for k = 1:2]) for i=1:gridsize[1],j=1:gridsize[2]])/nblocks
+    valpred = sum([prod([(maxshift[k] + 1 + u_real[k, i, j] - c[k, i, j])^2 for k in 1:2]) for i in 1:gridsize[1],j in 1:gridsize[2]]) / nblocks
     @test val ≈ valpred
-    for j = 1:gridsize[2], i = 1:gridsize[1]
-        @test ≈(g[i,j][1], 2*(maxshift[1]+1+u_real[1,i,j]-c[1,i,j])*(maxshift[2]+1+u_real[2,i,j]-c[2,i,j])^2/nblocks, atol=1000*eps()*accuracy)
-        @test ≈(g[i,j][2], 2*(maxshift[1]+1+u_real[1,i,j]-c[1,i,j])^2*(maxshift[2]+1+u_real[2,i,j]-c[2,i,j])/nblocks, atol=1000*eps()*accuracy)
+    for j in 1:gridsize[2], i in 1:gridsize[1]
+        @test ≈(g[i, j][1], 2 * (maxshift[1] + 1 + u_real[1, i, j] - c[1, i, j]) * (maxshift[2] + 1 + u_real[2, i, j] - c[2, i, j])^2 / nblocks, atol = 1000 * eps() * accuracy)
+        @test ≈(g[i, j][2], 2 * (maxshift[1] + 1 + u_real[1, i, j] - c[1, i, j])^2 * (maxshift[2] + 1 + u_real[2, i, j] - c[2, i, j]) / nblocks, atol = 1000 * eps() * accuracy)
     end
 end
 
@@ -129,25 +129,25 @@ end
 #################
 # So far we've done everything in 2d, but now test all relevant dimensionalities
 @testset "Total penalty" begin
-    for nd = 1:3
-        gridsize = tuple(collect(3:nd+2)...)
-        maxshift = collect(nd+2:-1:3)
-        imgaxs  = map(Base.OneTo, ((101:100+nd)...,))
-        shiftsize = 2maxshift.+1
+    for nd in 1:3
+        gridsize = tuple(collect(3:(nd + 2))...)
+        maxshift = collect((nd + 2):-1:3)
+        imgaxs = map(Base.OneTo, ((101:(100 + nd))...,))
+        shiftsize = 2maxshift .+ 1
         nblocks = prod(gridsize)
 
         # Set up the data penalty (nums and denoms)
         minrange = 1.6
-        maxrange = Float64[2*m+1-0.6 for m in maxshift]
-        dr = maxrange.-minrange
-        c = dr.*rand(nd, gridsize...).+minrange
-        nums = Array{Array{Float64,nd}}(undef, gridsize)
+        maxrange = Float64[2 * m + 1 - 0.6 for m in maxshift]
+        dr = maxrange .- minrange
+        c = dr .* rand(nd, gridsize...) .+ minrange
+        nums = Array{Array{Float64, nd}}(undef, gridsize)
         for I in CartesianIndices(gridsize)
             n = 1
-            for j = 1:nd
+            for j in 1:nd
                 s = ones(Int, nd)
                 s[j] = shiftsize[j]
-                n = n.*reshape([(x-c[j,I])^2 for x in 1:shiftsize[j]], s...)
+                n = n .* reshape([(x - c[j, I])^2 for x in 1:shiftsize[j]], s...)
             end
             nums[I] = n
         end
@@ -160,31 +160,31 @@ end
         dp = RegisterPenalty.AffinePenalty(ϕ.nodes, 0.0)
         g = similar(ϕ.u)
         val = RP.penalty!(g, ϕ, identity, dp, mmis)
-        @test abs(val) < 100*eps()
+        @test abs(val) < 100 * eps()
         gr = reshape(reinterpret(Float64, vec(g)), (nd, length(g)))
-        @test maximum(abs, gr) < 100*eps()
+        @test maximum(abs, gr) < 100 * eps()
 
         # Test derivatives with no uold
-        u_raw = dr.*rand(nd, gridsize...) .+ minrange .- maxshift .- 1  # a random location
+        u_raw = dr .* rand(nd, gridsize...) .+ minrange .- maxshift .- 1  # a random location
         ϕ = GridDeformation(u_raw, imgaxs)
         dx = u_raw - (c .- maxshift .- 1)
-        valpred = sum(prod(dx.^2,dims=1))/nblocks
+        valpred = sum(prod(dx .^ 2, dims = 1)) / nblocks
         g = similar(ϕ.u)
         val0 = RP.penalty!(g, ϕ, identity, dp, mmis)
         @test val0 ≈ valpred
         for I in CartesianIndices(gridsize)
-            for idim = 1:nd
-                gpred = 2/nblocks
-                for jdim = 1:nd
-                    gpred *= (jdim==idim) ? dx[jdim, I] : dx[jdim, I]^2
+            for idim in 1:nd
+                gpred = 2 / nblocks
+                for jdim in 1:nd
+                    gpred *= (jdim == idim) ? dx[jdim, I] : dx[jdim, I]^2
                 end
-                @test ≈(g[I][idim], gpred, atol=1000*eps()*accuracy)
+                @test ≈(g[I][idim], gpred, atol = 1000 * eps() * accuracy)
             end
         end
         # set lambda so the volume and data penalties contribute equally
         dp.λ = 1
         p = RP.penalty!(nothing, dp, ϕ)
-        dp.λ = val0/p
+        dp.λ = val0 / p
         val = RP.penalty!(g, ϕ, identity, dp, mmis)
         @test val ≈ 2val0
         if nd == 1
@@ -194,7 +194,7 @@ end
         end
 
         # Include uold
-        uold = dr.*rand(nd, gridsize...) .+ minrange .- maxshift .- 1
+        uold = dr .* rand(nd, gridsize...) .+ minrange .- maxshift .- 1
         ϕ_old = interpolate(GridDeformation(uold, imgaxs))
         val = RP.penalty!(g, ϕ, ϕ_old, dp, mmis)
         if nd == 1
@@ -211,29 +211,29 @@ end
 ### Temporal penalty
 ###
 @testset "Temporal penalty" begin
-    gsize = (3,4)
+    gsize = (3, 4)
     n = 3
-    x = randn(2*prod(gsize)*n)
-    nodes = (range(1, stop=100, length=3), range(1, stop=95, length=4))
+    x = randn(2 * prod(gsize) * n)
+    nodes = (range(1, stop = 100, length = 3), range(1, stop = 95, length = 4))
 
-    cnvt = x->RegisterPenalty.vec2ϕs(x, gsize, n, nodes)
+    cnvt = x -> RegisterPenalty.vec2ϕs(x, gsize, n, nodes)
     ϕs = cnvt(x)
     g = zeros(size(x))
     val = RegisterPenalty.penalty!(g, 1.0, ϕs)
-    gfx = ForwardDiff.gradient(x->RegisterPenalty.penalty(1.0, cnvt(x)), x)
+    gfx = ForwardDiff.gradient(x -> RegisterPenalty.penalty(1.0, cnvt(x)), x)
     @test vec(g) ≈ gfx
 
     ### Total penalty, with a temporal penalty
-    Qs = cat(Matrix{Float64}(I,2,2), zeros(2,2), Matrix{Float64}(I,2,2), dims = 3)
-    cs = cat([5,-3], [0,0], [3,-1], dims = 2)
-    gridsize = (2,2)
-    denom = ones(15,15)
-    mms = tighten([quadratic(cs[:,t], Qs[:,:,t], denom) for i = 1:gridsize[1], j = 1:gridsize[2], t = 1:3])
+    Qs = cat(Matrix{Float64}(I, 2, 2), zeros(2, 2), Matrix{Float64}(I, 2, 2), dims = 3)
+    cs = cat([5, -3], [0, 0], [3, -1], dims = 2)
+    gridsize = (2, 2)
+    denom = ones(15, 15)
+    mms = tighten([quadratic(cs[:, t], Qs[:, :, t], denom) for i in 1:gridsize[1], j in 1:gridsize[2], t in 1:3])
     mmis = RegisterPenalty.interpolate_mm!(mms)
-    nodes = (range(1, stop=100, length=gridsize[1]), range(1, stop=99, length=gridsize[2]))
+    nodes = (range(1, stop = 100, length = gridsize[1]), range(1, stop = 99, length = gridsize[2]))
     ap = RegisterPenalty.AffinePenalty(nodes, 1.0)
     u = randn(2, gridsize..., 3)
-    buildϕ(u, nodes) = [GridDeformation(u[:,:,:,t], nodes) for t = 1:size(u)[end]]
+    buildϕ(u, nodes) = [GridDeformation(u[:, :, :, t], nodes) for t in 1:size(u)[end]]
     ϕs = buildϕ(u, nodes)
     g = similar(u)
     λt = 1.0
@@ -242,13 +242,13 @@ end
         RegisterPenalty.penalty!(nothing, similarϕ(ϕs, x), identity, ap, λt, mmis)
     end
     # This is needed for handling GradientNumbers
-    function similarϕ(ϕs::Vector{GridDeformation{Tϕ,N,A,L}}, x::Array{Tx}) where {Tϕ,N,A,L,Tx}
-        len = N*length(first(ϕs).u)
-        length(x) == len*length(ϕs) || throw(DimensionMismatch("ϕs is incommensurate with a vector of length $(length(x))"))
-        xf = RegisterDeformation.convert_to_fixed(SVector{N,Tx}, x, (size(first(ϕs).u)..., length(ϕs)))
-        colons = ntuple(i->Colon(), N)::NTuple{N,Colon}
-        [GridDeformation(xf[colons..., i], ϕs[i].nodes) for i = 1:length(ϕs)]
+    function similarϕ(ϕs::Vector{GridDeformation{Tϕ, N, A, L}}, x::Array{Tx}) where {Tϕ, N, A, L, Tx}
+        len = N * length(first(ϕs).u)
+        length(x) == len * length(ϕs) || throw(DimensionMismatch("ϕs is incommensurate with a vector of length $(length(x))"))
+        xf = RegisterDeformation.convert_to_fixed(SVector{N, Tx}, x, (size(first(ϕs).u)..., length(ϕs)))
+        colons = ntuple(i -> Colon(), N)::NTuple{N, Colon}
+        [GridDeformation(xf[colons..., i], ϕs[i].nodes) for i in 1:length(ϕs)]
     end
-    gcmp = ForwardDiff.gradient(x->pfun(x, ϕs, ap, λt, mmis), vec(u))
+    gcmp = ForwardDiff.gradient(x -> pfun(x, ϕs, ap, λt, mmis), vec(u))
     @test vec(g) ≈ gcmp
 end


### PR DESCRIPTION
## Summary
- Apply `runic` formatting to `src/` and `test/`
- No functional changes — formatting only

## Test plan
- [x] Tests passed before formatting
- [x] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)